### PR TITLE
Fix link to Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Setup
 
   Requires Vagrant 1.5+.
 
-  See http://vagrant-up.com/downloads and https://www.virtualbox.org/wiki/Downloads for binary installers.
+  See http://vagrantup.com/downloads and https://www.virtualbox.org/wiki/Downloads for binary installers.
 
   If you're on Mac OS X, you probably want to install Homebrew (http://brew.sh/) because it makes installing Ansible easy, and because it is awesome anyway.
 


### PR DESCRIPTION
Note that http://vagrant-up.com/ is somebody's parked domain; we want `vagrantup`, without the dash.
